### PR TITLE
bfix: acceptance graph updating correctly

### DIFF
--- a/lib/presentation/profile/bloc/profile_bloc.dart
+++ b/lib/presentation/profile/bloc/profile_bloc.dart
@@ -53,6 +53,7 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
       return;
     }
 
+    _activity.clear();
     for (final activity in activityDetails ?? <ActivityDetails>[]) {
       if (activity.createdAt == null) continue;
       _activity[activity.createdAt!] = activity.correct;

--- a/lib/presentation/profile/widgets/acceptance_graph.dart
+++ b/lib/presentation/profile/widgets/acceptance_graph.dart
@@ -19,7 +19,6 @@ class AcceptanceGraph extends StatelessWidget {
             (previous.user != current.user);
       },
       builder: (context, state) {
-        print("Acceptance Graph Build");
         final bloc = context.read<ProfileBloc>();
         print(bloc.state.user);
         var day = 0;

--- a/lib/presentation/profile/widgets/acceptance_graph.dart
+++ b/lib/presentation/profile/widgets/acceptance_graph.dart
@@ -20,7 +20,6 @@ class AcceptanceGraph extends StatelessWidget {
       },
       builder: (context, state) {
         final bloc = context.read<ProfileBloc>();
-        print(bloc.state.user);
         var day = 0;
 
         final firstWeekDay = util.DateUtils.fistDayofMonth(

--- a/lib/presentation/profile/widgets/acceptance_graph.dart
+++ b/lib/presentation/profile/widgets/acceptance_graph.dart
@@ -15,10 +15,13 @@ class AcceptanceGraph extends StatelessWidget {
     return BlocBuilder<ProfileBloc, ProfileState>(
       buildWhen: (previous, current) {
         return (previous.currentYear != current.currentYear) ||
-            (previous.currentTriplet != current.currentTriplet);
+            (previous.currentTriplet != current.currentTriplet) ||
+            (previous.user != current.user);
       },
       builder: (context, state) {
+        print("Acceptance Graph Build");
         final bloc = context.read<ProfileBloc>();
+        print(bloc.state.user);
         var day = 0;
 
         final firstWeekDay = util.DateUtils.fistDayofMonth(


### PR DESCRIPTION
Fixes #104 

- Acceptance graph updates on changing user profile
- Acceptance graph now clears before being fetched again